### PR TITLE
Hilfedateien für MUL und DIV überarbeitet

### DIFF
--- a/help/en/DIV.htm
+++ b/help/en/DIV.htm
@@ -1,20 +1,27 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>DIV.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> DIV - Unsigned Divide<br>
-			<strong>Arguments:</strong> SRC: Register or memory location (8, 16 or 32 Bit)<br>
-			<strong>Usage:</strong> DIV SRC<br>
-			<strong>Effects:</strong> 8Bit SRC: AL:=AX / SRC; AH:=Remainder<br>
-16Bit SRC: AX:=DX:AX / SRC; DX:=Remainder<br>
-32Bit SRC: EAX:=EDX:EAX / SRC; EDX:=Remainder<br>
-Divedes (unsigned) the value in the pair of registers as  your can see above (according to the size of SRC) by SRC. The result of the division is saved in the lower part of the pair, the remainder is saved in the upper part of the pair.<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> The CF, OF, SF, ZF, AF, and PF flags are undefined.
-			<br><strong>Misc:</strong> Non-integral results are truncated towards 0.</div>
-			</body>
-			</html>
+<head>
+	<title>DIV.htm</title>
+</head>
+
+<body>
+	<div style="font-family: Helvetica,Arial,sans-serif; font-size: 11px;">
+	<strong>Command:</strong> DIV (Unsigned Divide)<br>
+	
+	<strong>Usage:</strong> DIV SRC<br>
+	
+	<strong>Arguments:</strong> SRC: Register or memory location (8, 16 or 32 Bit)<br>
+
+	<strong>Effects:</strong> MUL performs unsigned multiplication.<br>8Bit SRC: AL:=AX / SRC; AH:=Remainder<br>
+	16Bit SRC: AX:=DX:AX / SRC; DX:=Remainder<br>
+	32Bit SRC: EAX:=EDX:EAX / SRC; EDX:=Remainder<br>
+	Divides (unsigned) the value in the pair of registers as your can see above (according to the size of SRC) by SRC. The result of the division is saved in the lower part of the pair, the remainder is saved in the upper part of the pair.<br>
+	
+	<strong>Flags to be set:</strong> The CF, OF, SF, ZF, AF, and PF flags are undefined.<br>
+	
+	<strong>Misc:</strong> Non-integral results are truncated towards 0.</div>
+	</div>
+</body>
+</html>
 			

--- a/help/en/DIV.htm
+++ b/help/en/DIV.htm
@@ -9,9 +9,9 @@
 			<strong>Command:</strong> DIV - Unsigned Divide<br>
 			<strong>Arguments:</strong> SRC: Register or memory location (8, 16 or 32 Bit)<br>
 			<strong>Usage:</strong> DIV SRC<br>
-			<strong>Effects:</strong> 8Bit SRC: AL:=AX / SRC; AH:=Remainder<br>
-16Bit SRC: AX:=DX:AX / SRC; DX:=Remainder<br>
-32Bit SRC: EAX:=EDX:EAX / SRC; EDX:=Remainder<br>
+			<strong>Effects:</strong> 8Bit SRC: AL:=AX / SRC; AH:=remainder<br>
+16Bit SRC: AX:=DX:AX / SRC; DX:=remainder<br>
+32Bit SRC: EAX:=EDX:EAX / SRC; EDX:=remainder<br>
 Divedes (unsigned) the value in the pair of registers as  your can see above (according to the size of SRC) by SRC. The result of the division is saved in the lower part of the pair, the remainder is saved in the upper part of the pair.<br>
 			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> The CF, OF, SF, ZF, AF, and PF flags are undefined.
 			<br><strong>Misc:</strong> Non-integral results are truncated towards 0.</div>

--- a/help/en/DIV.htm
+++ b/help/en/DIV.htm
@@ -9,9 +9,9 @@
 			<strong>Command:</strong> DIV - Unsigned Divide<br>
 			<strong>Arguments:</strong> SRC: Register or memory location (8, 16 or 32 Bit)<br>
 			<strong>Usage:</strong> DIV SRC<br>
-			<strong>Effects:</strong> 8Bit SRC: AL:=AX / SRC; AH:=remainder<br>
-16Bit SRC: AX:=DX:AX / SRC; DX:=remainder<br>
-32Bit SRC: EAX:=EDX:EAX / SRC; EDX:=remainder<br>
+			<strong>Effects:</strong> 8Bit SRC: AL:=AX / SRC; AH:=Remainder<br>
+16Bit SRC: AX:=DX:AX / SRC; DX:=Remainder<br>
+32Bit SRC: EAX:=EDX:EAX / SRC; EDX:=Remainder<br>
 Divedes (unsigned) the value in the pair of registers as  your can see above (according to the size of SRC) by SRC. The result of the division is saved in the lower part of the pair, the remainder is saved in the upper part of the pair.<br>
 			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> The CF, OF, SF, ZF, AF, and PF flags are undefined.
 			<br><strong>Misc:</strong> Non-integral results are truncated towards 0.</div>

--- a/help/en/DIV.htm
+++ b/help/en/DIV.htm
@@ -9,9 +9,9 @@
 			<strong>Command:</strong> DIV - Unsigned Divide<br>
 			<strong>Arguments:</strong> SRC: Register or memory location (8, 16 or 32 Bit)<br>
 			<strong>Usage:</strong> DIV SRC<br>
-			<strong>Effects:</strong> 8Bit SRC: AL:=AX / SRC AH:=Rest
-16Bit SRC: AX:=DX:AX / SRC DX:=Rest
-32Bit SRC: EAX:=EDX:EAX / SRC EDX:=Rest
+			<strong>Effects:</strong> 8Bit SRC: AL:=AX / SRC; AH:=Remainder<br>
+16Bit SRC: AX:=DX:AX / SRC; DX:=Remainder<br>
+32Bit SRC: EAX:=EDX:EAX / SRC; EDX:=Remainder<br>
 Divedes (unsigned) the value in the pair of registers as  your can see above (according to the size of SRC) by SRC. The result of the division is saved in the lower part of the pair, the remainder is saved in the upper part of the pair.<br>
 			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> The CF, OF, SF, ZF, AF, and PF flags are undefined.
 			<br><strong>Misc:</strong> Non-integral results are truncated towards 0.</div>

--- a/help/en/MUL.htm
+++ b/help/en/MUL.htm
@@ -1,24 +1,26 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 
-			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-			<head>
-			<title>MUL.htm</title>
-			</head>
-			<body>
-			<div style="font-family:Helvetica,Arial,sans-serif;font-size:11px;">
-			<strong>Command:</strong> MUL-Unsigned Multiplication of AL or AX<br>
-			<strong>Arguments:</strong> DEST: any 8, 16 or 32 bit memory location or register<br>
-			<strong>Usage:</strong> MUL DEST<br>
-			<strong>Effects:</strong> MUL performs unsigned multiplication.
+<head>
+	<title>MUL.htm</title>
+</head>
 
-A byte operand is multiplied by AL; the result is left in AX. The carry and overflow flags are set to 0 if AH is 0; otherwise, they areset to 1.
+<body>
+	<div style="font-family: Helvetica,Arial,sans-serif; font-size: 11px;">
+	<strong>Command:</strong> MUL (Unsigned Multiplication of AL, AX or EAX)<br>
+	
+	<strong>Usage:</strong> MUL DEST<br>
+	
+	<strong>Arguments:</strong> DEST: Any 8, 16 or 32 bit memory location or register<br>
 
-A word operand is multiplied by AX; the result is left in DX:AX. DX contains the high-order 16 bits of the product. The carry and overflow flags are set to 0 if DX is 0; otherwise, they are set to 1.
-
-A doubleword operand is multiplied by EAX and the result is left in EDX:EAX. EDX contains the high-order 32 bits of the product. The carry and overflow flags are set to 0 if EDX is 0; otherwise, they are set to 1.
-<br>
-			<strong>Flags&nbsp;to&nbsp;be&nbsp;set:</strong> OF and CF as described; SF, ZF, AF, PF, and CF are undefined
-			
-			</body>
-			</html>
+	<strong>Effects:</strong> MUL performs unsigned multiplication.<br>
+	A byte operand is multiplied by AL; the result is left in AX. The carry and overflow flags are set to 0 if AH is 0; otherwise, they are set to 1.<br>
+	A word operand is multiplied by AX; the result is left in DX:AX. DX contains the high-order 16 bits of the product. The carry and overflow flags are set to 0 if DX is 0; otherwise, they are set to 1.<br>
+	A doubleword operand is multiplied by EAX; the result is left in EDX:EAX. EDX contains the high-order 32 bits of the product. The carry and overflow flags are set to 0 if EDX is 0; otherwise, they are set to 1.
+	<br>
+	
+	<strong>Flags to be set:</strong> OF and CF as described; SF, ZF, AF, PF, and CF are undefined<br>
+	</div>
+</body>
+</html>
 			


### PR DESCRIPTION
Die Hilfedateien zu MUL und DIV sind ziemlich unleserlich gewesen, sicherlich auch noch einige andere. Hier schon mal ein Anfang - weitere Überarbeitungen folgen zu gegebener Zeit. Leider kann der interne HTML-Viewer auch mit CSS und vielen HTML-Tags nicht umgehen, weswegen ich das alte, etwas flache Format beibehalten habe.