### PR TITLE
fix cmp reg, imm

### DIFF
--- a/src/jasmin/core/Parameters.java
+++ b/src/jasmin/core/Parameters.java
@@ -71,6 +71,7 @@ public class Parameters {
 			if (argument[i].address.dynamic) {
 				argument[i].calculateAddress(dsp);
 			} else {
+				argument[i].address.size = size;
 				argument[i].address.value = dsp.getInitial(argument[i], signed);
 			}
 		}


### PR DESCRIPTION
The CMP bug (#11) should be caused by a false conversion of the imm in DataSpace.getInitial(...), when no explicit size is given (size is then -1 and some shifts are done with this times 8).

This should fix it. 