### PR TITLE
commands as labels

### DIFF
--- a/src/jasmin/core/Parser.java
+++ b/src/jasmin/core/Parser.java
@@ -497,9 +497,9 @@ public class Parser {
 				return null;
 			}
 			int labeltype = getOperandType(label);
-			if (commandLoader.commandExists(label)) {
-				return null;
-			}
+			//if (commandLoader.commandExists(label)) {
+			//	return null;
+			//}
 			if (Op.matches(labeltype, Op.ERROR | Op.LABEL | Op.VARIABLE | Op.CONST)) {
 				return label;
 			}

--- a/src/jasmin/gui/SyntaxHighlighter.java
+++ b/src/jasmin/gui/SyntaxHighlighter.java
@@ -434,9 +434,13 @@ public class SyntaxHighlighter extends DefaultStyledDocument {
 		// highlight everything with default style
 		setCharacterAttributes(startOffset, length, normal, true);
 		
+		String lineWithoutCommand = line;
+		int startOffsetAfterCommand = startOffset;
 		// highlight commands
 		if (pr.mnemo != null) {
 			applyStyle(pr.mnemo, command, line, startOffset);
+			lineWithoutCommand = line.substring(pr.mnemo.length());
+			startOffsetAfterCommand += pr.mnemo.length();
 		}
 		
 		// highlight registers
@@ -450,7 +454,7 @@ public class SyntaxHighlighter extends DefaultStyledDocument {
 			highlightLabel(pr.label, line, startOffset);
 		}
 		for (String labelstring : pr.usedLabels) {
-			highlightLabel(labelstring, line, startOffset);
+			highlightLabel(labelstring, lineWithoutCommand, startOffsetAfterCommand);
 		}
 		
 		// highlight errors


### PR DESCRIPTION
Commands as labels works out of the box with disabling an internal check.
The only thing which wasn't working out of the box was syntax highlighting.
Should be working now, too. 
#13 