### PR TITLE
Fix for no updates with small registers, eg. ADD al,8

### DIFF
--- a/src/jasmin/core/Address.java
+++ b/src/jasmin/core/Address.java
@@ -14,7 +14,7 @@ public class Address {
 	public boolean dynamic = false;
 	
 	// special stuff for registers
-	public long shortcut;
+	public LongWrapper shortcut;
 	public int rshift;
 	public long mask;
 
@@ -57,7 +57,7 @@ public class Address {
 	}
 	
 	public long getShortcut() {
-		return (shortcut & mask) >> rshift;
+		return (shortcut.value & mask) >> rshift;
 	}
 	
 }

--- a/src/jasmin/core/LongWrapper.java
+++ b/src/jasmin/core/LongWrapper.java
@@ -1,0 +1,9 @@
+package jasmin.core;
+
+public class LongWrapper {
+	public long value;
+
+	public LongWrapper() {
+		value = 0L;
+	}
+}

--- a/src/jasmin/core/Registers.java
+++ b/src/jasmin/core/Registers.java
@@ -12,7 +12,7 @@ public class Registers {
 
 	private int NUMREG = 9; // A, B, C, D, SI, DI, SP, BP, IP
 
-	private long[] reg;
+	private LongWrapper[] reg;
 
 	/**
 	 * the dirty tag / works like a time stamp
@@ -27,10 +27,11 @@ public class Registers {
 
 	// @SuppressWarnings("unchecked")
 	public Registers() {
-		reg = new long[9];
+		reg = new LongWrapper[9];
 		dirty = new int[NUMREG];
                 dirtyParts = new int[NUMREG];
 		for (int i = 0; i < NUMREG; i++) {
+			reg[i] = new LongWrapper();
 			dirty[i] = Integer.MIN_VALUE;
                         dirtyParts[i] = 0;
 		}
@@ -129,7 +130,7 @@ public class Registers {
 
                 // Set the value
 		value <<= address.rshift;
-		address.shortcut = (address.shortcut & ~address.mask) | (value & address.mask);
+		address.shortcut.value = (address.shortcut.value & ~address.mask) | (value & address.mask);
 
                 // Set the "time" of last change
 		this.dirty[address.address] = dirtyTimeStamp;
@@ -160,7 +161,7 @@ public class Registers {
 	 */
 	public void reset() {
 		for (int i = 0; i < NUMREG; i++) {
-			reg[i] = 0L;
+			reg[i].value = 0L;
 		}
 		clearDirty();
 	}


### PR DESCRIPTION
For this I reintroduce the LongWrapper class which purpose was to reference a single registervalue from multiple address objects. This is necessary since the address object for EAX is not the same as for any subregister (AX, AH, AL). In order to change the value of a register correctly each address object needs a reference to the register value, which cannot be achieved with plain primitives.
