### PR TITLE
Keep the operand's intrinsic size for the initial value conversion.

### DIFF
--- a/src/jasmin/core/Parameters.java
+++ b/src/jasmin/core/Parameters.java
@@ -67,7 +67,10 @@ public class Parameters {
 			if (argument[i].address.dynamic) {
 				argument[i].calculateAddress(dsp);
 			} else {
+				int previous_size = argument[i].address.size;
+				argument[i].address.size = size;
 				argument[i].address.value = dsp.getInitial(argument[i], signed);
+				argument[i].address.size = previous_size;
 			}
 		}
 	}


### PR DESCRIPTION
This should fix #11 and #39. @werpat already tried to fix it in #14. This commit just resets the operand's size back to the default one before the value conversion.